### PR TITLE
Channel emotes

### DIFF
--- a/bttv.ts
+++ b/bttv.ts
@@ -1,0 +1,18 @@
+import { getUsers } from './twitch.ts'
+
+export const getBttvEmotes = (userId: string) =>
+  fetch(`https://api.betterttv.net/3/cached/users/twitch/${userId}`)
+    .then(response => response.json())
+    .then(({ channelEmotes, sharedEmotes }) =>
+      channelEmotes.concat(sharedEmotes)
+    )
+
+export const getFFEmotes = (userId: string) =>
+  fetch(
+    `https://api.betterttv.net/3/cached/frankerfacez/users/twitch/${userId}`
+  ).then(response => response.json())
+
+export const getChannelEmotes = (channel: string) =>
+  getUsers({ login: [channel] })
+    .then(([{ id }]) => Promise.all([getBttvEmotes(id), getFFEmotes(id)]))
+    .then(([bttvEmotes, ffEmotes]) => bttvEmotes.concat(ffEmotes))

--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,7 @@ config({ export: true })
 import { Application, Router, parseJSON } from './deps.ts'
 import i18n from './i18n.ts'
 import { users, channel } from './twitch.ts'
+import { getChannelEmotes } from './bttv.ts'
 
 const router = new Router()
 router
@@ -40,6 +41,11 @@ router
             : ''
         )
         .then(chatter => (response.body = chatter))
+  )
+  .get('/channels/:channel/emotes', ({ response, params: { channel } }) =>
+    getChannelEmotes(channel!)
+      .then(emotes => emotes.map((emote: { code: string }) => emote.code))
+      .then(emotes => (response.body = emotes.join(' ')))
   )
 
 const app = new Application()

--- a/twitch.ts
+++ b/twitch.ts
@@ -45,7 +45,7 @@ const request = (endpoint: string, params = {}) =>
     }).then(r => r.json())
   )
 
-const getUsers = ({
+export const getUsers = ({
   id = [],
   login = [],
 }: {


### PR DESCRIPTION
A nice channel command to have is the one that shows the current channel emotes. This PR implements it.

You can add this functionality in Nightbot by creating a command like:

```
!addcom !emotes $(urlfetch https://your-twitch-utils-url/channels/$(querystring $(channel))/emotes)
```

and in Phantombot:

```
!addcom !emotes (customapi https://your-twitch-utils-url/channels/(channelname)/emotes)
```