### PR TITLE
Channel emotes pagination

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,23 @@
+export const paginateWords = (pageNumber: number, size = 500) => (
+  words: string[]
+) => {
+  const pages = words.reduce(
+    (result: { text: string[]; length: number }[], curr) => {
+      if (
+        result.length &&
+        result[result.length - 1].length + curr.length + 1 <= size
+      ) {
+        result[result.length - 1].text.push(curr)
+        result[result.length - 1].length += curr.length + 1
+      } else {
+        result.push({ text: [curr], length: curr.length })
+      }
+      return result
+    },
+    []
+  )
+
+  const page = (pages[pageNumber - 1] || { text: [] }).text
+
+  return { pages: pages.length, page, size }
+}


### PR DESCRIPTION
Some channels have emotes lists larger than 500 characters when displayed, so this PR adds a `page` query parameter to the `/emotes` endpoint giving 500 characters chunks and the first page by default. Custom headers informing the current chunk size and page count are also added to the response.